### PR TITLE
Fix PHPDoc $strict description and guide examples for FormHydrator

### DIFF
--- a/docs/guide/en/form-hydrator.md
+++ b/docs/guide/en/form-hydrator.md
@@ -167,7 +167,7 @@ use Yiisoft\FormModel\FormModel;
  * @var RequestInterface $request 
  */
  
-$isPopulated = $formHydrator->populate($formModel, $request);
+$isPopulated = $formHydrator->populateFromPost($formModel, $request);
 ```
 
 ### `populateFromPostAndValidate()`
@@ -186,8 +186,8 @@ use Yiisoft\FormModel\FormModel;
  */
 
 
-$isValid = $formHydrator->populateAndValidate($formModel, $request);
-$result = $form->getValidationResult();
+$isValid = $formHydrator->populateFromPostAndValidate($formModel, $request);
+$result = $formModel->getValidationResult();
 ```
 
 The parameters are the same as in [`populate()`](#populate). But, unlike [`validate()`](#validate), the method returns

--- a/src/FormHydrator.php
+++ b/src/FormHydrator.php
@@ -136,7 +136,7 @@ final class FormHydrator
      * setting.
      * @psalm-param MapType $map
      * @param ?bool $strict If `false`, fills everything that is in the data. If `null`, fills data that is either
-     * defined in a map explicitly or allowed via validation rules. If `false`, fills only data defined explicitly
+     * defined in a map explicitly or allowed via validation rules. If `true`, fills only data defined explicitly
      * in a map or only data allowed via validation rules but not both.
      * @param ?string $scope Key to use in the data array as a source of data. Usually used when there are multiple
      * forms at the same page. If not set, it equals to {@see FormModelInterface::getFormName()}.
@@ -165,7 +165,7 @@ final class FormHydrator
      * setting.
      * @psalm-param MapType $map
      * @param ?bool $strict If `false`, fills everything that is in the data. If `null`, fills data that is either
-     * defined in a map explicitly or allowed via validation rules. If `false`, fills only data defined explicitly
+     * defined in a map explicitly or allowed via validation rules. If `true`, fills only data defined explicitly
      * in a map or only data allowed via validation rules but not both.
      * @param ?string $scope Key to use in the data array as a source of data. Usually used when there are multiple
      * forms at the same page. If not set, it equals to {@see FormModelInterface::getFormName()}.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

This PR fixes documentation for `FormHydrator::populateFromPost()` and `FormHydrator::populateFromPostAndValidate()` methods.

No code changes, documentation only.

Closes #84.