### PR TITLE
Fix #91: Add `color()` method to `Field` and `FieldFactory` for HTML5 input color support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.2 under development
 
-- Enh #91: Add `color()` method to `Field` and `FieldFactory` for HTML5 input color support
+- New #91: Add `color()` method to `Field` and `FieldFactory` for HTML5 input color support (@Mister-42)
 
 ## 1.1.1 March 21, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.2 under development
 
-- no changes in this release.
+- Enh #91: Add `color()` method to `Field` and `FieldFactory` for HTML5 input color support
 
 ## 1.1.1 March 21, 2026
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -8,6 +8,7 @@ use Yiisoft\Form\Field\Button;
 use Yiisoft\Form\Field\ButtonGroup;
 use Yiisoft\Form\Field\Checkbox;
 use Yiisoft\Form\Field\CheckboxList;
+use Yiisoft\Form\Field\Color;
 use Yiisoft\Form\Field\Date;
 use Yiisoft\Form\Field\DateTimeLocal;
 use Yiisoft\Form\Field\Email;
@@ -111,6 +112,25 @@ class Field
         ?string $theme = null,
     ): CheckboxList {
         return CheckboxList::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
+            ->inputData(new FormModelInputData($formModel, $property));
+    }
+
+    /**
+     * Create a color field.
+     *
+     * @param FormModelInterface $formModel Model to take value from.
+     * @param string $property Model property name to take value from.
+     * @param array $config Widget config.
+     * @param string|null $theme Theme to use. If not specified, default theme is used.
+     * @return Color
+     */
+    final public static function color(
+        FormModelInterface $formModel,
+        string $property,
+        array $config = [],
+        ?string $theme = null,
+    ): Color {
+        return Color::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
             ->inputData(new FormModelInputData($formModel, $property));
     }
 

--- a/src/FieldFactory.php
+++ b/src/FieldFactory.php
@@ -8,6 +8,7 @@ use Yiisoft\Form\Field\Button;
 use Yiisoft\Form\Field\ButtonGroup;
 use Yiisoft\Form\Field\Checkbox;
 use Yiisoft\Form\Field\CheckboxList;
+use Yiisoft\Form\Field\Color;
 use Yiisoft\Form\Field\Date;
 use Yiisoft\Form\Field\DateTimeLocal;
 use Yiisoft\Form\Field\Email;
@@ -113,6 +114,25 @@ class FieldFactory
         ?string $theme = null,
     ): CheckboxList {
         return CheckboxList::widget(config: $config, theme: $theme ?? $this->defaultTheme)
+            ->inputData(new FormModelInputData($formModel, $property));
+    }
+
+    /**
+     * Create a color field.
+     *
+     * @param FormModelInterface $formModel Model to take value from.
+     * @param string $property Model property name to take value from.
+     * @param array $config Widget config.
+     * @param string|null $theme Theme to use. If not specified, default theme is used.
+     * @return Color
+     */
+    final public function color(
+        FormModelInterface $formModel,
+        string $property,
+        array $config = [],
+        ?string $theme = null,
+    ): Color {
+        return Color::widget(config: $config, theme: $theme ?? $this->defaultTheme)
             ->inputData(new FormModelInputData($formModel, $property));
     }
 

--- a/tests/FieldFactoryTest.php
+++ b/tests/FieldFactoryTest.php
@@ -190,6 +190,45 @@ final class FieldFactoryTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testColor(): void
+    {
+        $result = (new FieldFactory())->color(new TestForm(), 'color')->render();
+        $this->assertSame(
+            <<<HTML
+            <div>
+            <label for="testform-color">Select color</label>
+            <input type="color" name="TestForm[color]" id="testform-color">
+            <div>Color of box.</div>
+            </div>
+            HTML,
+            $result,
+        );
+    }
+
+    public function testColorWithTheme(): void
+    {
+        ThemeContainer::initialize([
+            'A' => [
+                'containerClass' => 'red',
+            ],
+            'B' => [
+                'containerClass' => 'green',
+            ],
+        ]);
+
+        $result = (new FieldFactory('A'))->color(new TestForm(), 'color', theme: 'B')->render();
+        $this->assertSame(
+            <<<HTML
+            <div class="green">
+            <label for="testform-color">Select color</label>
+            <input type="color" name="TestForm[color]" id="testform-color">
+            <div>Color of box.</div>
+            </div>
+            HTML,
+            $result,
+        );
+    }
+
     public function testDate(): void
     {
         $result = (new FieldFactory())->date(new TestForm(), 'birthday')->render();

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -191,6 +191,45 @@ final class FieldTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testColor(): void
+    {
+        $result = Field::color(new TestForm(), 'color')->render();
+        $this->assertSame(
+            <<<HTML
+            <div>
+            <label for="testform-color">Select color</label>
+            <input type="color" name="TestForm[color]" id="testform-color">
+            <div>Color of box.</div>
+            </div>
+            HTML,
+            $result,
+        );
+    }
+
+    public function testColorWithTheme(): void
+    {
+        ThemeContainer::initialize([
+            'A' => [
+                'containerClass' => 'red',
+            ],
+            'B' => [
+                'containerClass' => 'green',
+            ],
+        ]);
+
+        $result = FieldWithTheme::color(new TestForm(), 'color', theme: 'B')->render();
+        $this->assertSame(
+            <<<HTML
+            <div class="green">
+            <label for="testform-color">Select color</label>
+            <input type="color" name="TestForm[color]" id="testform-color">
+            <div>Color of box.</div>
+            </div>
+            HTML,
+            $result,
+        );
+    }
+
     public function testDate(): void
     {
         $result = Field::date(new TestForm(), 'birthday')->render();


### PR DESCRIPTION
Implements `Field::color()` and `FieldFactory::color()` to support HTML5 `<input type="color">` fields, closing #79.

The `Color` widget already existed in `yiisoft/form` — this just exposes it through the form-model bridge.